### PR TITLE
Add removeOne & removeMany functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,15 @@ Instance methods summary:
 
 * `add(value)`: add an element into the queue; runs in `O(log n)` time.
 * `poll()`: remove and return the element on top of the heap (smallest element); runs in `O(log n)` time. If the priority queue is empty, the function returns `undefined`.
-* `remove(value[, comparator])`: remove the given item, if found, from the queue. The item is found by using the queue's comparator (if a new comparator function isn't provided). A custom comparator is useful if you want to remove based on a seperate key value, not necessarily priority. Returns `true` if an item is removed, `false` otherwise.
+* `remove(value)`: remove the given item, if found, from the queue. The item is found by using the queue's comparator. Returns `true` if the item is removed, `false` otherwise.
+* `removeOne(callback)`: execute the callback function for each item of the queue and remove the first item for which the callback will return true. Returns the removed item, or `null` if nothing is removed.
+* `removeMany(callback[, limit])`: execute the callback function for each item of the queue and remove each item for which the callback will return true, up to a max limit of removed items if specified or no limit if unspecified. Returns an array containing the removed items.
 * `replaceTop(value)`: `poll()` and `add(value)` in one operation. This is useful for [fast, top-k queries](http://lemire.me/blog/2017/06/21/top-speed-for-top-k-queries/). Returns the removed element, similar to `poll()`.
 * `heapify(array)`: replace the content of the heap with the provided array, then order it based on the comparator.
 * `peek()`: return the top of the queue (smallest element) without removal; runs in `O(1)` time.
 * `isEmpty()`: return `true` if the the queue has no elements, false otherwise.
 * `clone()`: copy the priority queue into another, and return it. Queue items are shallow-copied. Runs in `O(n)` time.
-* `forEach(callback)`: iterate over all items in the priority queue from smallest to largest. `callback` should be a function that accepts two arguements, `value` (the item), and `index`, the zero-based index of the item.
+* `forEach(callback)`: iterate over all items in the priority queue from smallest to largest. `callback` should be a function that accepts two arguments, `value` (the item), and `index`, the zero-based index of the item.
 * `trim()`: clean up unused memory in the heap; useful after high-churn operations like many `add()`s then `remove()`s.
 
 # npm install

--- a/unit/basictests.js
+++ b/unit/basictests.js
@@ -100,6 +100,48 @@ describe('FastPriorityQueue', function() {
     checkOrderNonVolatile(x, [0, 5, 8]);
   });
 
+  it('removeOne', function() {
+    var x = new FastPriorityQueue();
+    x.heapify([8, 6, 7, 5, 3, 0, 9, 1, 0]);
+
+    var callback = function(val) {
+      return val === 1;
+    }
+
+    var removedItem = x.removeOne(callback);
+    if (removedItem !== 1) throw 'bug';
+    checkOrderNonVolatile(x, [0, 0, 3, 5, 6, 7, 8, 9]);
+
+    removedItem = x.removeOne(callback);
+    if (removedItem !== null) throw 'bug';
+    checkOrderNonVolatile(x, [0, 0, 3, 5, 6, 7, 8, 9]);
+  });  
+
+  it('removeMany', function() {
+    var x = new FastPriorityQueue();
+    x.heapify([8, 9, 9, 2, 1, 0, 4, 6, 2, 7, 6, 8, 7, 8, 0, 6, 7, 1, 6, 1, 7, 8, 3, 8, 4, 1, 2, 9, 6, 1, 8, 7, 2, 7, 7, 8, 8, 5, 8, 8]);
+
+    var callback = function(val) {
+      return val === 6;
+    }
+    var removedItems = x.removeMany(callback);
+    if (removedItems.length !== 5 || x.size !== 35) throw 'bug';
+    checkOrderNonVolatile(x, [0,0,1,1,1,1,1,2,2,2,2,3,4,4,5,7,7,7,7,7,7,7,8,8,8,8,8,8,8,8,8,8,9,9,9]);
+
+    callback = function(val) {
+      return val > 6;
+    }
+    removedItems = x.removeMany(callback);
+    if (removedItems.length !== 20 || x.size !== 15) throw 'bug';
+    checkOrderNonVolatile(x, [0,0,1,1,1,1,1,2,2,2,2,3,4,4,5]);
+
+    callback = function(val) {
+      return true;
+    }
+    removedItems = x.removeMany(callback, 10);
+    if (removedItems.length !== 10 || x.size !== 5) throw 'bug';
+  });
+
   it('Random', function() {
     for (var ti = 0; ti < 100; ti++) {
       var b = new FastPriorityQueue(function(a, b) {

--- a/unit/basictests.js
+++ b/unit/basictests.js
@@ -142,6 +142,37 @@ describe('FastPriorityQueue', function() {
     if (removedItems.length !== 10 || x.size !== 5) throw 'bug';
   });
 
+  it('removeMany remove all - one item', function() {
+    var x = new FastPriorityQueue();
+    x.heapify([1]);
+
+    var callback = function (val) {
+      return true;
+    }
+
+    var removedItems = x.removeMany(callback);
+    if (removedItems.length !== 1 || x.size !== 0) throw 'bug';
+  });
+
+  it('removeMany remove all - more then one item', function() {
+    var x = new FastPriorityQueue();
+    x.heapify([1,2]);
+
+    var callback = function (val) {
+      return true;
+    }
+
+    var removedItems = x.removeMany(callback);
+    if (removedItems.length !== 2 || x.size !== 0) {
+      console.log('removed: ' + JSON.stringify(removedItems));
+      console.log('remaining:');
+      while (!x.isEmpty()) {
+        console.log(x.poll());
+      }
+      throw 'bug';
+    }
+  });
+
   it('Random', function() {
     for (var ti = 0; ti < 100; ti++) {
       var b = new FastPriorityQueue(function(a, b) {


### PR DESCRIPTION
This adds functionality to remove multiple items from the queue with a single call. It works similar to the `remove` method. I will update the README in this PR so don't merge yet but I thought I would just check that the logic looks correct.