### PR TITLE
Use undefined return types

### DIFF
--- a/FastPriorityQueue.js
+++ b/FastPriorityQueue.js
@@ -125,9 +125,9 @@ FastPriorityQueue.prototype._percolateDown = function(i) {
 
 // internal
 // _removeAt(index) will remove the item at the given index from the queue,
-// retaining balance. returns the removed item, or null if nothing is removed.
+// retaining balance. returns the removed item, or undefined if nothing is removed.
 FastPriorityQueue.prototype._removeAt = function(index) {
-  if (index > this.size - 1 || index < 0) return null;
+  if (index > this.size - 1 || index < 0) return undefined;
 
   // impl1:
   //this.array.splice(index, 1);
@@ -146,7 +146,7 @@ FastPriorityQueue.prototype.remove = function(myval) {
       continue;
     }
     // items are equal, remove
-    return this._removeAt(i) !== null;
+    return this._removeAt(i) !== undefined;
   }
 };
 
@@ -159,7 +159,7 @@ FastPriorityQueue.prototype._batchRemove = function(callback, limit) {
 
   if (typeof callback === 'function' && this.size) {
     var i = 0;
-    do {
+    while (i < this.size && count < retArr.length) {
       if (callback(this.array[i])) {
         retArr[count] = this._removeAt(i);
         count++;
@@ -168,7 +168,7 @@ FastPriorityQueue.prototype._batchRemove = function(callback, limit) {
       } else {
         i++;
       }
-    } while (i < this.size && count < retArr.length);
+    } 
   }
   retArr.length = count;
   return retArr;
@@ -176,10 +176,10 @@ FastPriorityQueue.prototype._batchRemove = function(callback, limit) {
 
 // removeOne(callback) will execute the callback function for each item of the queue
 // and will remove the first item for which the callback will return true.
-// return the removed item, or null if nothing is removed.
+// return the removed item, or undefined if nothing is removed.
 FastPriorityQueue.prototype.removeOne = function(callback) {
   var arr = this._batchRemove(callback, 1);
-  return arr[0] ? arr[0] : null;
+  return arr.length > 0 ? arr[0] : undefined;
 };
 
 // remove(callback[, limit]) will execute the callback function for each item of
@@ -293,7 +293,8 @@ FastPriorityQueue.prototype.kSmallest = function(k) {
 }
 
 // just for illustration purposes
-var main = function() {// main code
+var main = function() {
+  // main code
   var x = new FastPriorityQueue(function(a, b) {
     return a < b;
   });

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ Instance methods summary:
 * `add(value)`: add an element into the queue; runs in `O(log n)` time.
 * `poll()`: remove and return the element on top of the heap (smallest element); runs in `O(log n)` time. If the priority queue is empty, the function returns `undefined`.
 * `remove(value)`: remove the given item, if found, from the queue. The item is found by using the queue's comparator. Returns `true` if the item is removed, `false` otherwise.
-* `removeOne(callback)`: execute the callback function for each item of the queue and remove the first item for which the callback will return true. Returns the removed item, or `null` if nothing is removed.
+* `removeOne(callback)`: execute the callback function for each item of the queue and remove the first item for which the callback will return true. Returns the removed item, or `undefined` if nothing is removed.
 * `removeMany(callback[, limit])`: execute the callback function for each item of the queue and remove each item for which the callback will return true, up to a max limit of removed items if specified or no limit if unspecified. Returns an array containing the removed items.
-* `replaceTop(value)`: `poll()` and `add(value)` in one operation. This is useful for [fast, top-k queries](http://lemire.me/blog/2017/06/21/top-speed-for-top-k-queries/). Returns the removed element, similar to `poll()`.
+* `replaceTop(value)`: `poll()` and `add(value)` in one operation. This is useful for [fast, top-k queries](http://lemire.me/blog/2017/06/21/top-speed-for-top-k-queries/). Returns the removed element or `undefined`, similar to `poll()`.
 * `heapify(array)`: replace the content of the heap with the provided array, then order it based on the comparator.
-* `peek()`: return the top of the queue (smallest element) without removal; runs in `O(1)` time.
+* `peek()`: return the top of the queue (smallest element) without removal, or `undefined` if the queue is empty; runs in `O(1)` time.
 * `isEmpty()`: return `true` if the the queue has no elements, false otherwise.
 * `clone()`: copy the priority queue into another, and return it. Queue items are shallow-copied. Runs in `O(n)` time.
 * `forEach(callback)`: iterate over all items in the priority queue from smallest to largest. `callback` should be a function that accepts two arguments, `value` (the item), and `index`, the zero-based index of the item.

--- a/unit/basictests.js
+++ b/unit/basictests.js
@@ -102,18 +102,22 @@ describe('FastPriorityQueue', function() {
 
   it('removeOne', function() {
     var x = new FastPriorityQueue();
-    x.heapify([8, 6, 7, 5, 3, 0, 9, 1, 0]);
-
+    
     var callback = function(val) {
       return val === 1;
     }
 
     var removedItem = x.removeOne(callback);
+    if (removedItem !== undefined) throw 'bug';
+
+    x.heapify([8, 6, 7, 5, 3, 0, 9, 1, 0]);
+
+    removedItem = x.removeOne(callback);
     if (removedItem !== 1) throw 'bug';
     checkOrderNonVolatile(x, [0, 0, 3, 5, 6, 7, 8, 9]);
 
     removedItem = x.removeOne(callback);
-    if (removedItem !== null) throw 'bug';
+    if (removedItem !== undefined) throw 'bug';
     checkOrderNonVolatile(x, [0, 0, 3, 5, 6, 7, 8, 9]);
   });  
 


### PR DESCRIPTION
This changes the return type of `removeOne` from `null` to `undefined` to match the behavior of other methods which return `undefined` in the empty case. Also updates the readme to explicitly mention `undefined` return types and adds a `removeOne` empty test case.